### PR TITLE
Changed entity name from "Alarm" to "AllAlarm" to fix code generation issue

### DIFF
--- a/allalarm.spec
+++ b/allalarm.spec
@@ -282,7 +282,7 @@
         "create": false,
         "delete": false,
         "description": "The alarm API allows the management of system alarms.",
-        "entity_name": "Alarm",
+        "entity_name": "AllAlarm",
         "extends": [
             "@audited",
             "@base",


### PR DESCRIPTION
Changed entity name from "Alarm" to "AllAlarm" in allalarm.spec in order to fix code generation issue with Java, Python and probably other code generators. Without that change, the generated Enterprise class ends up with two attributes called 'alarms', that is because both "alarm" and "allalarm" child specs have the same entity name. 
