### PR TITLE
Improve CI

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -8,7 +8,28 @@ WORKSPACE=$(pwd)
 function generate_sdk()
 {
     local language=${1}
-    generate-vspk -f . -L ${language}
+    local version=${2}
+
+    # for Python and HTML, we want to generate SDKs from multiple branches
+    if [ "${language}" == "python" -o "${language}" == "html" ] ; then
+        case ${version} in
+            5.0.*) local branches="master 4.0" ;;
+            4.0.*) local branches="4.0 3.2" ;;
+            3.2.*) local branches="3.2" ;;
+            *)
+                >&2 echo "Unexpected version number \"${version}\". Cannot chose which branche(s) to build."
+                exit 1
+                ;;
+        esac
+    else
+        local branches="${ACTUAL_BRANCH}"
+    fi
+
+    generate-vspk \
+        --generation-version ${version} \
+        -b ${branches} \
+        -f . \
+        -L ${language}
 }
 
 function update_repo()
@@ -51,10 +72,13 @@ function main()
 {
     local language=
     local languages="python go java objj html vro"
+    local last_tag=$(git describe --tags --abbrev=0)
+    # tags look  like r4.0.6.1, we make the version 4.0.6.1
+    local version=${last_tag:1}
 
     install_vspkgenerator
     for language in ${languages} ; do
-        generate_sdk ${language}
+        generate_sdk ${language} ${version}
         if [[ ${TRAVIS_PULL_REQUEST} == "false" ]] ; then
             update_repo ${language}
         fi


### PR DESCRIPTION
- use latest monolithe & vspkgenerator
- generate SDKs from multiple branches for html and python.
- specify the version when generating the SDK. The version is taken from
  the last tag in the current branch.